### PR TITLE
Removes color change for borders.

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -160,9 +160,6 @@ ts-jumper input[type="text"],
     background-color: var(--border-dim);
 }
 
-.c-message_attachment__border {
-	background-color: var(--background-elevated) !important;
-}
 .c-member_slug--link {
     background: var(--background-elevated);
 }


### PR DESCRIPTION
This PR removes the attachment color override for messages from this: 

![image](https://user-images.githubusercontent.com/12258802/45762814-367bc080-bbfd-11e8-9a03-39d136bc160b.png)

to this: ✨ 

![image](https://user-images.githubusercontent.com/12258802/45762946-82c70080-bbfd-11e8-8a52-9101daf4cb60.png)

This is useful for automated messages where you'd like a status at a glance.

