### PR TITLE
Corrected MacOS behavior for appending

### DIFF
--- a/darkSlack.sh
+++ b/darkSlack.sh
@@ -59,15 +59,15 @@ if [[ $APP_VER == app-4* ]]; then
 
 	sudo npx asar extract "${SLACK_RESOURCES_DIR}"/app.asar "${SLACK_RESOURCES_DIR}"/app.asar.unpacked
 
-	sudo tee -a "${SLACK_FILE_PATH_4}" > /dev/null <<< $(cat interjectCode.js)
+	cat interjectCode.js | sudo tee -a "${SLACK_FILE_PATH_4}" > /dev/null
 
 	sudo npx asar pack "${SLACK_RESOURCES_DIR}"/app.asar.unpacked "${SLACK_RESOURCES_DIR}"/app.asar
 fi
 
 if [[ $APP_VER == app-3* ]]; then
 	echo "Updating Slack 3 code.."
-	sudo tee -a "${SLACK_FILE_PATH_3}" > /dev/null <<< $(cat interjectCode.js)
-	sudo tee -a "${SLACK_FILE_PATH_3_1}" > /dev/null <<< $(cat interjectCode.js)
+	cat interjectCode.js | sudo tee -a "${SLACK_FILE_PATH_3}" > /dev/null
+	cat interjectCode.js | sudo tee -a "${SLACK_FILE_PATH_3_1}" > /dev/null
 fi
 
 echo ""


### PR DESCRIPTION
Before this change, the ssb-interop.bundle.js file looked like this:
![image](https://user-images.githubusercontent.com/33518609/61965384-0e3bbb80-af9e-11e9-8e1a-c8355cb96167.png)

After this change, it looks like this:
![image](https://user-images.githubusercontent.com/33518609/61965453-4216e100-af9e-11e9-97ef-a19e7085f2ba.png)

For some reason, using the syntax `tee -a someFile > /dev/null <<< $(cat anotherFile)` doesn't preserve the newline characters or whitespace at the beginning of each line. I did notice that if you switch from LF to CRLF it preserves line breaks. But `cat anotherFile | tee -a someFile > /dev/null` was the only way I found that preserved both newlines, and whitespace at the beginning of each line.