### PR TITLE
fix another css var typo

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -1769,7 +1769,7 @@ ts-jumper .p-jumper__help {
 }
 /* message not allowed */
 #msg_input_message {
-	background-color: var(--bacground-elevated);
+	background-color: var(--background-elevated);
 }
 
 .internal_im_link,


### PR DESCRIPTION
just did this in the browser editor and can't seem to avoid that end of file linebreak change, but hopefully it doesn't matter.